### PR TITLE
Fix a ruby verision detection

### DIFF
--- a/lib/tree_rb/extension_digest.rb
+++ b/lib/tree_rb/extension_digest.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-if RUBY_VERSION =~ /1\.8/
+if RUBY_VERSION =~ /\A1\.8/
   # std lib
   require 'md5'
 else


### PR DESCRIPTION
Problem example: version 2.1.8 should not be detected as 1.8.x.
